### PR TITLE
feat(search): location searches use UUID

### DIFF
--- a/backend/inventory/templates/items/public_search.html
+++ b/backend/inventory/templates/items/public_search.html
@@ -20,6 +20,7 @@
             {% else %}
             <input type="text" class="form-control" id="search-input" placeholder="Search by name, manufacturer, or GTIN..." />
             {% endif %}
+            <small class="text-muted d-none" id="location-only-notice"></small>
           </div>
 
           <div class="col-md-3 mb-3">
@@ -1069,6 +1070,7 @@
   let searchTimeout = null;
   let loadedItems = []; // Store all loaded items
   let urlOnlyLocationUuid = '';
+  let selectedLocationName = '{{ selected_location_name|default:""|escapejs }}';
   let hasInternalPermission = {% if perms.inventory.view_internalstockingdetails %}true{% else %}false{% endif %}; // Django template variable
   let currentRequest = null; // Track current AJAX request
 
@@ -1149,6 +1151,24 @@
           tagStates[tagId.trim()] = 'exclude';
         }
       });
+    }
+
+    updateLocationOnlyNotice(params);
+  }
+
+  function updateLocationOnlyNotice(params = getURLParams()) {
+    const noticeEl = $('#location-only-notice');
+    if (!noticeEl.length) {
+      return;
+    }
+
+    if (params.location_uuid) {
+      const locationName = (params.location || '').trim() || selectedLocationName || 'Selected location';
+      noticeEl.text(`Searching only Location "${locationName}"`);
+      noticeEl.removeClass('d-none');
+    } else {
+      noticeEl.addClass('d-none');
+      noticeEl.text('');
     }
   }
 
@@ -1497,6 +1517,7 @@
       $('#sort-by').val('last_updated');
       $('#sort-order').val('desc');
       urlOnlyLocationUuid = '';
+      updateLocationOnlyNotice({ location_uuid: '', location: '' });
 
       // Update counts and reload items
       if (typeof updateTagCount === 'function') {

--- a/backend/inventory/templates/items/public_search.html
+++ b/backend/inventory/templates/items/public_search.html
@@ -1068,6 +1068,7 @@
   let currentViewMode = 'tile'; // 'tile' or 'table'
   let searchTimeout = null;
   let loadedItems = []; // Store all loaded items
+  let urlOnlyLocationUuid = '';
   let hasInternalPermission = {% if perms.inventory.view_internalstockingdetails %}true{% else %}false{% endif %}; // Django template variable
   let currentRequest = null; // Track current AJAX request
 
@@ -1087,6 +1088,7 @@
     url.searchParams.delete('sort_by');
     url.searchParams.delete('sort_order');
     url.searchParams.delete('location');
+    url.searchParams.delete('location_uuid');
     url.searchParams.delete('offset');
 
     // Add new parameters
@@ -1114,6 +1116,7 @@
       sort_by: urlParams.get('sort_by') || 'last_updated',
       sort_order: urlParams.get('sort_order') || 'desc',
       location: urlParams.get('location') || '',
+      location_uuid: urlParams.get('location_uuid') || '',
     };
   }
 
@@ -1125,6 +1128,7 @@
     $('#exclude-expired').prop('checked', params.exclude_expired);
     $('#sort-by').val(params.sort_by);
     $('#sort-order').val(params.sort_order);
+    urlOnlyLocationUuid = params.location_uuid;
 
     // Set location search if available and user has permission
     if ($('#location-input').length) {
@@ -1492,6 +1496,7 @@
       $('#exclude-expired').prop('checked', false);
       $('#sort-by').val('last_updated');
       $('#sort-order').val('desc');
+      urlOnlyLocationUuid = '';
 
       // Update counts and reload items
       if (typeof updateTagCount === 'function') {
@@ -1588,6 +1593,10 @@
       sort_by: $('#sort-by').val(),
       sort_order: $('#sort-order').val()
     };
+
+    if (urlOnlyLocationUuid) {
+      params.location_uuid = urlOnlyLocationUuid;
+    }
 
     // Add location search if user has permission and field is visible
     if ($('#location-search-container').is(':visible')) {

--- a/backend/inventory/templates/items/public_search.html
+++ b/backend/inventory/templates/items/public_search.html
@@ -20,7 +20,12 @@
             {% else %}
             <input type="text" class="form-control" id="search-input" placeholder="Search by name, manufacturer, or GTIN..." />
             {% endif %}
-            <small class="text-muted d-none" id="location-only-notice"></small>
+            <div class="alert alert-info d-none mt-2 mb-0 py-2 px-3" id="location-only-notice" role="status" aria-live="polite">
+              <div class="d-flex align-items-center">
+              <i class="material-icons me-2" style="font-size: 1rem">place</i>
+              <span id="location-only-notice-text"></span>
+              </div>
+            </div>
           </div>
 
           <div class="col-md-3 mb-3">
@@ -1158,17 +1163,18 @@
 
   function updateLocationOnlyNotice(params = getURLParams()) {
     const noticeEl = $('#location-only-notice');
+    const noticeTextEl = $('#location-only-notice-text');
     if (!noticeEl.length) {
       return;
     }
 
     if (params.location_uuid) {
       const locationName = (params.location || '').trim() || selectedLocationName || 'Selected location';
-      noticeEl.text(`Searching only Location "${locationName}"`);
+      noticeTextEl.text(`Searching only Location "${locationName}"`);
       noticeEl.removeClass('d-none');
     } else {
       noticeEl.addClass('d-none');
-      noticeEl.text('');
+      noticeTextEl.text('');
     }
   }
 

--- a/backend/inventory/templates/locations/location_list.html
+++ b/backend/inventory/templates/locations/location_list.html
@@ -32,7 +32,7 @@
             </td>
             <td>
               {% if location.stock_item_count > 0 %}
-              <a href="{% url 'public_search' %}?search={{ location.name|urlencode }}" class="text-decoration-none"> {{ location.stock_item_count }} </a>
+              <a href="{% url 'public_search' %}?location_uuid={{ location.id }}" class="text-decoration-none"> {{ location.stock_item_count }} </a>
               {% else %} {{ location.stock_item_count }} {% endif %}
             </td>
             <td class="text-right">

--- a/backend/inventory/views/items.py
+++ b/backend/inventory/views/items.py
@@ -949,8 +949,18 @@ def public_search_view(request):
         )
     ).order_by('sort_order', 'name')
     
+    selected_location_name = ""
+    location_uuid = request.GET.get('location_uuid', '').strip()
+    if location_uuid:
+        try:
+            location_uuid = str(UUID(location_uuid))
+            selected_location_name = models.Location.objects.filter(id=location_uuid).values_list('name', flat=True).first() or ""
+        except (ValueError, TypeError, AttributeError):
+            selected_location_name = ""
+
     context = {
         'tag_groups': tag_groups,
+        'selected_location_name': selected_location_name,
     }
     
     template = loader.get_template("items/public_search.html")

--- a/backend/inventory/views/items.py
+++ b/backend/inventory/views/items.py
@@ -1053,10 +1053,6 @@ def public_search_api(request):
                 Q(item__tags__name__icontains=search_query) |  # Search in tag names
                 Q(item__tags__tag_group__name__icontains=search_query)  # Search in tag group names
             )
-        
-        # Add location search only for users with internal details permission
-        if has_internal_details_perm:
-            search_conditions |= Q(location_new__name__icontains=search_query)
     
     
     stock_items_query = stock_items_query.filter(search_conditions)

--- a/backend/inventory/views/items.py
+++ b/backend/inventory/views/items.py
@@ -21,6 +21,7 @@ from inventory.forms_tags import TaggedItemForm, TaggedItemWithStockForm
 from inventory.models import Item, AuditEvent, StockItem, CheckOutItem, Tag, TagGroup
 from .utils import audit_log_state, audit_log_event
 from django.db.models import Prefetch
+from uuid import UUID
 
 def view_item_detail(request, uuid):
     """
@@ -966,6 +967,7 @@ def public_search_api(request):
         offset: Starting position for pagination (default: 0)
         limit: Maximum number of results to return (default: 20, max: 100)
         search: General search query across name, manufacturer, GTIN, and tags
+        location_uuid: Optional location UUID to restrict items to stock at that location
         tag_groups: Comma-separated list of tag group IDs to filter by
         tags: Comma-separated list of tag IDs to filter by
         exclude_expired: Exclude expired items (true/false, default: false)
@@ -993,6 +995,7 @@ def public_search_api(request):
     
     # Get filter parameters
     search_query = request.GET.get('search', '').strip()
+    location_uuid = request.GET.get('location_uuid', '').strip()
 
     tag_ids = request.GET.get('tags', '').strip()
     excluded_tag_ids = request.GET.get('excluded_tags', '').strip()
@@ -1015,6 +1018,20 @@ def public_search_api(request):
     # Filter for permission-based access - only show surplus-approved items for public users
     if not has_internal_details_perm:
         stock_items_query = stock_items_query.filter(surplus_status__in=['not_wanted'])
+
+    # URL-only location filter: keep only stock items at a specific location UUID.
+    if location_uuid:
+        try:
+            location_uuid = str(UUID(location_uuid))
+        except (ValueError, TypeError, AttributeError):
+            return JsonResponse({
+                'items': [],
+                'total_count': 0,
+                'offset': offset,
+                'limit': limit,
+                'has_more': False,
+            })
+        stock_items_query = stock_items_query.filter(location_new_id=location_uuid)
     
     # Apply search filter to stock items and their related items
     search_conditions = Q()


### PR DESCRIPTION
Previously, in manage locations, when clicking on the stock items it would just
do a text search, which would be very unreliable ("Box 1" would match to "Box 10").
Instead, now we just set a url parameter to filter for that UUID. It also shows a nice
box to remind the user that they are filtering by that box.